### PR TITLE
Crash fix for PlasticSCM 8.0.16.3000 and newer

### DIFF
--- a/PlasticSourceControl.uplugin
+++ b/PlasticSourceControl.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 37,
-	"VersionName": "1.4.2",
+	"VersionName": "1.4.3",
 	"FriendlyName": "Plastic SCM",
 	"Description": "Plastic source control management",
 	"Category": "Source Control",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To release the plugin, zip the _Plugins_ folder. But before that, remove the _In
 
 ### Status
 
-#### Version 1.4.2 2019/01/22 for UE4.21:
+#### Version 1.4.3 2019/03/01 for UE4.21:
 - manage connection to the server
 - show current branch name and CL in status text
 - display status icons to show controlled/checked-out/added/deleted/private/changed/ignored files
@@ -105,6 +105,7 @@ To release the plugin, zip the _Plugins_ folder. But before that, remove the _In
 - [Partial Checkin (like Gluon, for artists)](http://blog.plasticscm.com/2015/03/plastic-gluon-is-out-version-control.html)
 - Plastic Cloud is fully supported
 - xlinks sub-repositories (for Plugins for instance)
+- support legacy status command from PlasticSCM version 8.0.16.3000 (crash fix)
 - Windows only
 
 #### Feature Requests

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -862,7 +862,11 @@ static bool RunStatus(const TArray<FString>& InFiles, const EConcurrency::Type I
 			ParseFileStatusResult(FileVisitor.Files, Results, OutStates, OutChangeset, OutBranchName);
 			// The above cannot detect assets removed / locally deleted since there is no file left to enumerate (either by the Content Browser or by File Manager)
 			// => so we also parse the status results to explicitly look for Removed/Deleted assets
-			Results.RemoveAt(0, 2); // Before that, remove the first two line Changeset, and BranchName
+
+			// Command-line format output changed with version 8.0.16.3000, so we only need to do this for older versions.
+			if (PlasticScmVersionLess(CurrentVersion, NewFormatVersion)) {
+				Results.RemoveAt(0, 2); // Before that, remove the first two line Changeset, and BranchName
+			}
 			ParseDirectoryStatusResult(Results, OutStates);
 		}
 		else

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -405,6 +405,36 @@ void GetPlasticScmVersion(FString& OutPlasticScmVersion)
 	}
 }
 
+/**
+ * @brief Compare Plastic SCM cli version strings.
+ * @param VersionA		PlasticSCM version string in the form "0.0.0.0" (as returned by GetPlasticScmVersion)
+ * @param VersionB		PlasticSCM version string in the form "0.0.0.0" (as returned by GetPlasticScmVersion)
+ * @returns true if VersionA is lower than VersionB
+*/
+static bool PlasticScmVersionLess(const FString& VersionA, const FString& VersionB) {
+	struct Version {
+		Version(const FString& V) {
+			TArray<FString> Parts;
+			const int32 N = V.ParseIntoArray(Parts, TEXT("."));
+			check(N == 4);
+			a = FCString::Atoi(*Parts[0]);
+			b = FCString::Atoi(*Parts[1]);
+			c = FCString::Atoi(*Parts[2]);
+			d = FCString::Atoi(*Parts[3]);
+		}
+		int a, b, c, d;
+	} A(VersionA), B(VersionB);
+	if (A.a < B.a) return true;
+	if (B.a < A.a) return false;
+	if (A.b < B.b) return true;
+	if (B.b < A.b) return false;
+	if (A.c < B.c) return true;
+	if (B.c < A.c) return false;
+	if (A.d < B.d) return true;
+	if (B.d < A.d) return false;
+	return false; // Equal
+}
+
 void GetUserName(FString& OutUserName)
 {
 	TArray<FString> InfoMessages;
@@ -785,6 +815,14 @@ static bool RunStatus(const TArray<FString>& InFiles, const EConcurrency::Type I
 	Parameters.Add(TEXT("--noheaders"));
 	Parameters.Add(TEXT("--all"));
 	Parameters.Add(TEXT("--ignored"));
+
+	// Command-line format output changed with version 8.0.16.3000, plugin will crash unless we demand the old format.
+	FString NewFormatVersion = "8.0.16.3000";
+	FString CurrentVersion;
+	PlasticSourceControlUtils::GetPlasticScmVersion(CurrentVersion);
+	if (!PlasticScmVersionLess(CurrentVersion, NewFormatVersion)) {
+		Parameters.Add(TEXT("--cset"));
+	}
 	// "cm status" only operate on one path (file or folder) at a time, so use one folder path for multiple files in a directory
 	const FString Path = FPaths::GetPath(*InFiles[0]);
 	TArray<FString> OnePath;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -811,17 +811,20 @@ static bool RunStatus(const TArray<FString>& InFiles, const EConcurrency::Type I
 	ensure(0 < InFiles.Num());
 
 	TArray<FString> Parameters;
-	Parameters.Add(TEXT("--wkconfig"));
-	Parameters.Add(TEXT("--noheaders"));
-	Parameters.Add(TEXT("--all"));
-	Parameters.Add(TEXT("--ignored"));
 
 	// Command-line format output changed with version 8.0.16.3000, plugin will crash unless we demand the old format.
+	// For more details, see https://www.plasticscm.com/download/releasenotes/oldernotes?release=8.0.16.3000
 	FString NewFormatVersion = "8.0.16.3000";
 	FString CurrentVersion;
 	PlasticSourceControlUtils::GetPlasticScmVersion(CurrentVersion);
 	if (!PlasticScmVersionLess(CurrentVersion, NewFormatVersion)) {
-		Parameters.Add(TEXT("--cset"));
+		Parameters.Add(TEXT("--compact"));
+	}
+	else {
+		Parameters.Add(TEXT("--wkconfig"));
+		Parameters.Add(TEXT("--noheaders"));
+		Parameters.Add(TEXT("--all"));
+		Parameters.Add(TEXT("--ignored"));
 	}
 	// "cm status" only operate on one path (file or folder) at a time, so use one folder path for multiple files in a directory
 	const FString Path = FPaths::GetPath(*InFiles[0]);


### PR DESCRIPTION
The `cm status` command output format changed in version 8.0.16.3000 of PlasticSCM (as documented in the release notes here), and this change caused the UE4PlasticPlugin to crash Unreal due to the `RunStatus` trying to remove 2 elements from an array that now only contained 1 element.

In addition to this, several flags to the `cm status` command have been removed, renamed or deprecated and so we need to check the version of the CLI to deal with the new behaviour appropriately.

I have tested this on official Unreal Engine 4.21.2 using both PlasticSCM 7.0.16.2904 and PlasticSCM 8.0.16.3000 to verify that the plugin continues to work on old and new versions.

Fixes #58 