### PR TITLE
Don't report warning when a file is locked

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -947,7 +947,7 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 		if ((FileState.WorkspaceState != EWorkspaceState::CheckedOut) && (FileState.WorkspaceState != EWorkspaceState::Moved) && (0 < FileState.LockedBy.Len())) 
 		{
 			// @todo: temporary debug log
-			UE_LOG(LogSourceControl, Warning, TEXT("LockedByOther(%s) by '%s!=%s' (or %s!=%s)"), *File, *FileState.LockedBy, *Provider.GetUserName(), *FileState.LockedWhere, *Provider.GetWorkspaceName());
+			UE_LOG(LogSourceControl, Log, TEXT("LockedByOther(%s) by '%s!=%s' (or %s!=%s)"), *File, *FileState.LockedBy, *Provider.GetUserName(), *FileState.LockedWhere, *Provider.GetWorkspaceName());
 			FileState.WorkspaceState = EWorkspaceState::LockedByOther;
 		}
 


### PR DESCRIPTION
On project start-up, our log is spammed by yellow warnings: `LogSourceControl: Warning: LockedByOther(file) by 'email1!=email2' (or Project!=)`

I usually pay attention to all warnings and fix them up, so for me this specific warning is deceptive: there's nothing to be warn about, it's not an unexpected state that some files are locked by other people, files that I usually don't want to touch anyways.

I propose reducing the severity to `Log`, as it's really just a "note".