### PR TITLE
Shorten PlasticSCM user names for display

### DIFF
--- a/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
+++ b/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
@@ -23,6 +23,7 @@ public class PlasticSourceControl : ModuleRules
 				"XmlParser2",
 				"Projects",
 				"AssetRegistry",
+				"DeveloperSettings",
 			}
 		);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -12,4 +12,11 @@ class UPlasticSourceControlProjectSettings : public UDeveloperSettings
 	GENERATED_BODY()
 
 public:
+	/** Map Plastic SCM user names (typically e-mail addresses or company domain names) to display names for brevity. */
+	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM")
+	TMap<FString,FString> UserNameToDisplayName;
+
+	/** Hide the domain part of an username e-mail address (eg @gmail.com) if the UserNameToDisplayName map didn't match (enabled by default). */
+	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM")
+	bool bHideEmailDomainInUsername = true;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -6,7 +6,8 @@
 #include "Engine/DeveloperSettings.h"
 #include "PlasticSourceControlProjectSettings.generated.h"
 
-UCLASS(config = Engine, NotPlaceable, meta = (DisplayName = "Plastic SCM"))
+/** Project Settings for Plastic SCM Source Control. Saved in Config/DefaultEditor.ini */
+UCLASS(config = Editor, defaultconfig, meta = (DisplayName = "Source Control - Plastic SCM"))
 class UPlasticSourceControlProjectSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2022 Codice Software
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "PlasticSourceControlProjectSettings.generated.h"
+
+UCLASS(config = Engine, NotPlaceable, meta = (DisplayName = "Plastic SCM"))
+class UPlasticSourceControlProjectSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+};

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2016-2022 Codice Software
 
 #include "PlasticSourceControlUtils.h"
+
 #include "PlasticSourceControlCommand.h"
 #include "PlasticSourceControlModule.h"
+#include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlSettings.h"
 #include "PlasticSourceControlState.h"
 #include "Runtime/Launch/Resources/Version.h"
@@ -564,6 +566,24 @@ bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FS
 	}
 
 	return bResult;
+}
+
+FString UserNameToDisplayName(const FString& InUserName)
+{
+	if (const FString* Result = GetDefault<UPlasticSourceControlProjectSettings>()->UserNameToDisplayName.Find(InUserName))
+	{
+		return *Result;
+	}
+	else if (GetDefault<UPlasticSourceControlProjectSettings>()->bHideEmailDomainInUsername)
+	{
+		int32 EmailDomainSeparatorIndex;
+		if (InUserName.FindChar(TEXT('@'), EmailDomainSeparatorIndex))
+		{
+			return InUserName.Left(EmailDomainSeparatorIndex);
+		}
+	}
+
+	return InUserName;
 }
 
 /**
@@ -1530,7 +1550,7 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 				}
 				if (const FXmlNode* OwnerNode = RevisionNode->FindChildNode(Owner))
 				{
-					SourceControlRevision->UserName = OwnerNode->GetContent();
+					SourceControlRevision->UserName = UserNameToDisplayName(OwnerNode->GetContent());
 				}
 				if (const FXmlNode* DateNode = RevisionNode->FindChildNode(CreationDate))
 				{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -966,7 +966,7 @@ public:
 				RepSpec = MoveTemp(Fileinfos[2]);
 				if (NbElmts >=4)
 				{
-					LockedBy = MoveTemp(Fileinfos[3]);
+					LockedBy = UserNameToDisplayName(MoveTemp(Fileinfos[3]));
 					if (NbElmts >= 5)
 					{
 						LockedWhere = MoveTemp(Fileinfos[4]);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -82,9 +82,18 @@ bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName,
  * @param	OutRepositoryName	Name of the repository of the current workspace
  * @param	OutServerUrl		URL/Port of the server of the repository
  * @param	OutBranchName		Name of the current checked-out branch
-  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
+ * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  */
 bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName, TArray<FString>& OutErrorMessages);
+
+/**
+ * Use the Project Settings to replace Plastic SCM full username/e-mail by a shorter version for display.
+ *
+ * Used when retrieving the username of a revision, to display in history and content browser asset tooltip.
+ *
+ * @param	InUserName			The Plastic SCM username to shorten for display.
+ */
+FString UserNameToDisplayName(const FString& InUserName);
 
 /**
  * Run a Plastic command - output is a string TArray.


### PR DESCRIPTION
Add Project Settings to configure:
- Map PlasticSCM user names (typically e-mail addresses or company domain names) to display names for brevity.
- Hide the domain part of a username e-mail address (eg @gmail.com) if the map above didn't match. Enabled by default.

Fixes #99 and #100 