### PR TITLE
Add a setting to bypass checkout and let the user directly modify the assets

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -20,4 +20,8 @@ public:
 	/** Hide the domain part of an username e-mail address (eg @gmail.com) if the UserNameToDisplayName map didn't match (enabled by default). */
 	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM")
 	bool bHideEmailDomainInUsername = true;
+
+	/** If enabled, you'll be prompted to check out changed files */
+	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM")
+	bool bPromptForCheckoutOnChange = true;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -5,6 +5,7 @@
 #include "PlasticSourceControlCommand.h"
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlOperations.h"
+#include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlSettings.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
@@ -343,7 +344,7 @@ bool FPlasticSourceControlProvider::UsesChangelists() const
 
 bool FPlasticSourceControlProvider::UsesCheckout() const
 {
-	return true;
+	return GetDefault<UPlasticSourceControlProjectSettings>()->bPromptForCheckoutOnChange;
 }
 
 TSharedPtr<IPlasticSourceControlWorker, ESPMode::ThreadSafe> FPlasticSourceControlProvider::CreateWorker(const FName& InOperationName) const


### PR DESCRIPTION
Let's add a project setting that toggles the appearance of the Checkout Assets dialog every time the user tries to save an asset whose file isn't checked out.

As Plastic SCM doesn't require files to be checked out, it might be annoying for some users to get notified about that with every change.

![image](https://user-images.githubusercontent.com/4534635/174105053-8ee3561d-ba82-443e-a032-dc75cd3b4e72.png)

When toggled on, the plugin will behave as it did until now:
* A popup will show whenever they change an asset that isn't checked out
* The Checkout Assets dialog will show when they save a changed file that isn't checked out

When toggled off, the user won't have any of those. They'll be able to freely change and save files regardless of their checked-out status. They'll be able to checkin any locally changed files normally using the "Submit to Source Control..." option in the Source Control menu.
