### PR TITLE
User connected to a cloud server can open the Dashboard

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -28,6 +28,7 @@ public:
 	void ShowSourceControlPlasticScmProjectSettings() const;
 	void VisitDocsURLClicked() const;
 	void VisitSupportURLClicked() const;
+	void VisitLockRulesURLClicked(const FString OrganizationName) const;
 
 private:
 	bool IsSourceControlConnected() const;


### PR DESCRIPTION
### What
Adds a new button to the global revision control menu to open Lock Rules in Unity's Dashboard if the workspace points to a cloud organization
### How
- It checks server's url and looks for @cloud to find out if it is a cloud organization.
- If positive if shows a new button saying "Configure Lock Rules" ("Navigate to lock rules configuration page in the Unity Dashboard.")
- If clicked on the button it launches a url pointing to Lock Rules configuration page for the cloud organization (using 'default' as generic id)